### PR TITLE
Force electrode names to upper case

### DIFF
--- a/R/topoplot.R
+++ b/R/topoplot.R
@@ -59,6 +59,8 @@ topoplot <- function(df,
         warnings("No channel locations found in chanLocs.")
       }
     } else if ("electrode" %in% colnames(df)) {
+      df$electrode <- toupper(df$electrode)
+      electrodeLocs$electrode <- toupper(electrodeLocs$electrode)
       df <- left_join(df, electrodeLocs, by = "electrode")
       message("Adding standard electrode locations...")
     } else {


### PR DESCRIPTION
This allows using default electrode locations when electrode names in data are differently cased than names in default locs.

This fixes issue #1 