### PR TITLE
Use `bslib` instead of `miniUI`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - `topoplot()` now supports plotting of multiple timepoints - pass a list of times to the `time_lim` argument.
 - `topoplot()` now supports custom fill titles through the `fill_title` argument, and automatically switches where necessary (e.g. now says "Power mV^2"). Fill titles are now also centred.
 - `browse_data.eeg_ICA()` now provides the option to select components for rejection, and returns a character vector of selected components.
+- Recoded `browse_data()` to use `bslib` for styling.
 - `view_ica()` now allows you to select components for rejection, to double-click on topographies to inspect them individually, and to return cleaned data.
 - `eeg_average()` now supports averaging over conditions in `eeg_evoked` files
 - `eeg_average()` now records weights - the number of epochs that went into an average - and uses those in subsequent steps where possible for `eeg_epochs`/`eeg_evoked` / `eeg_tfr` objects. 

--- a/R/artefact_viewer.R
+++ b/R/artefact_viewer.R
@@ -7,7 +7,6 @@
 #' @import shiny
 #' @import ggplot2
 #' @param data Object to be explored.
-#' @return Nothing.
 #' @examples
 #'   \dontrun{ view_artefacts(demo_epochs) }
 #' @export
@@ -29,29 +28,28 @@ view_artefacts <- function(data) {
                                   values_from = value)
 
   ui <-
-    navbarPage("Artefact checks",
+    bslib::page_navbar(title = "Artefact checks",
       inverse = TRUE,
-      tabPanel("Channel stats",
-               sidebarLayout(
-                 sidebarPanel(selectInput("chan_meas",
-                                          "Display measures",
-                                          choices = c("means",
-                                                      "sds",
-                                                      "variance",
-                                                      "kurtosis",
-                                                      "minmax")
-                                         ),
-                              checkboxInput("std_meas",
-                                            "Standardize?"),
-                              width = 3),
-                 mainPanel(
-                   plotly::plotlyOutput("chan_plot"),
-                   fluidRow(
-                            column(6, plotly::plotlyOutput("erpplot")),
-                            column(6, plotly::plotlyOutput("erpimage"))),
-                 ),
-               )),
-      tabPanel("Epoch stats", epoch_plotly(epoch_dat))
+      bslib::nav_panel(
+        title = "Channel stats",
+        bslib::layout_sidebar(
+          sidebar = bslib::sidebar(
+            shiny::selectInput("chan_meas",
+                               "Display measures",
+                               choices = c("means",
+                                           "sds",
+                                           "variance",
+                                           "kurtosis",
+                                           "minmax")
+                               ),
+            shiny::checkboxInput("std_meas",
+                                 "Standardize?")),
+          plotly::plotlyOutput("chan_plot"),
+          plotly::plotlyOutput("erpplot"),
+          plotly::plotlyOutput("erpimage")
+          )
+        ),
+      bslib::nav_panel("Epoch stats", epoch_plotly(epoch_dat))
     )
 
   server <- function(input, output) {
@@ -147,8 +145,8 @@ epoch_plotly <- function(id,
 
   ns <- shiny::NS(id)
 
-  tagList(
-    fluidRow(
+  shiny::tagList(
+    shiny::fluidRow(
       plotly::plotlyOutput("plotly_emeans",
                            height = 250),
       plotly::plotlyOutput("plotly_evars",

--- a/R/data_viewers.R
+++ b/R/data_viewers.R
@@ -158,9 +158,6 @@ browse_data.eeg_data <- function(data,
   }
 
   ui <- bslib::page_fillable(
-    tags$head(
-      tags$style(".resize-vertical {resize: vertical;}")
-    ),
     title = ("Continuous data browser"),
     bslib::navset_tab(
       bslib::nav_panel(
@@ -168,7 +165,7 @@ browse_data.eeg_data <- function(data,
         icon = shiny::icon("chart-line"),
         bslib::card(
           shiny::plotOutput("butterfly"),
-          class = "resize-vertical"
+          style = "resize:vertical;"
         )
       ),
       bslib::nav_panel(
@@ -177,8 +174,7 @@ browse_data.eeg_data <- function(data,
         bslib::card(
           shiny::wellPanel(
             shiny::plotOutput("time_plot"),
-            style = "overflow-y:scroll; max-height: 800px",
-            class = "resize-vertical"
+            style = "overflow-y:scroll; max-height: 800px; resize:vertical",
           ),
         )
       ),
@@ -289,9 +285,6 @@ browse_data.eeg_epochs <- function(data,
   }
 
   ui <- bslib::page_fillable(
-    tags$head(
-      tags$style(".resize-vertical {resize: vertical;}")
-    ),
     title = "Epoched data browser",
     bslib::navset_tab(
       bslib::nav_panel(
@@ -303,7 +296,7 @@ browse_data.eeg_epochs <- function(data,
           "Shows traces from every electrode overlapping, with transparency"),
         bslib::card(
           shiny::plotOutput("butterfly"),
-          class = "resize-vertical"
+          style = "resize:vertical;"
         ),
       ),
       bslib::nav_panel(
@@ -316,8 +309,7 @@ browse_data.eeg_epochs <- function(data,
         ),
         bslib::card(
           shiny::plotOutput("time_plot"),
-          style = "overflow-y:scroll; max-height: 800px",
-          class = "resize-vertical"
+          style = "overflow-y:scroll; max-height: 800px; resize:vertical;",
         )
       ),
       footer = bslib::card(

--- a/R/data_viewers.R
+++ b/R/data_viewers.R
@@ -164,7 +164,7 @@ browse_data.eeg_data <- function(data,
         title = "Butterfly",
         icon = shiny::icon("chart-line"),
         bslib::card(
-          shiny::plotOutput("butterfly"),
+          shiny::plotOutput("butterfly")
         )
       ),
       bslib::nav_panel(
@@ -277,6 +277,9 @@ browse_data.eeg_epochs <- function(data,
   }
 
   ui <- bslib::page_fillable(
+    tags$head(
+      tags$style(".resize-vertical {resize: vertical;}")
+    ),
     title = "Epoched data browser",
     bslib::navset_tab(
       bslib::nav_panel(
@@ -288,6 +291,7 @@ browse_data.eeg_epochs <- function(data,
           "Shows traces from every electrode overlapping, with transparency"),
         bslib::card(
           shiny::plotOutput("butterfly"),
+          class = "resize-vertical"
         ),
       ),
 
@@ -304,6 +308,7 @@ browse_data.eeg_epochs <- function(data,
         bslib::card(
           shiny::plotOutput("time_plot"),
           style = "overflow-y:scroll; max-height: 800px",
+          class = "resize-vertical"
         ),
       ),
       footer = bslib::card(

--- a/R/data_viewers.R
+++ b/R/data_viewers.R
@@ -344,8 +344,13 @@ browse_data.eeg_epochs <- function(data,
       #               "Remove DC offset",
       #               value = FALSE)
       bslib::nav_panel(
-        title = "Individual",
-        icon = shiny::icon("chart-line"),
+        title = bslib::tooltip(
+          shiny::tags$span(
+            "Individual",
+            shiny::icon("chart-line"),
+          ),
+          "Show traces for each electrode separately"
+          ),
         bslib::card(
           shiny::plotOutput("time_plot"),
           #style = "overflow-y:scroll; max-height: 800px;overflow-x:scroll",

--- a/R/data_viewers.R
+++ b/R/data_viewers.R
@@ -158,13 +158,17 @@ browse_data.eeg_data <- function(data,
   }
 
   ui <- bslib::page_fillable(
+    tags$head(
+      tags$style(".resize-vertical {resize: vertical;}")
+    ),
     title = ("Continuous data browser"),
     bslib::navset_tab(
       bslib::nav_panel(
         title = "Butterfly",
         icon = shiny::icon("chart-line"),
         bslib::card(
-          shiny::plotOutput("butterfly")
+          shiny::plotOutput("butterfly"),
+          class = "resize-vertical"
         )
       ),
       bslib::nav_panel(
@@ -173,7 +177,8 @@ browse_data.eeg_data <- function(data,
         bslib::card(
           shiny::wellPanel(
             shiny::plotOutput("time_plot"),
-            style = "overflow-y:scroll; max-height: 800px"
+            style = "overflow-y:scroll; max-height: 800px",
+            class = "resize-vertical"
           ),
         )
       ),

--- a/R/data_viewers.R
+++ b/R/data_viewers.R
@@ -11,7 +11,6 @@
 #'@author Matt Craddock \email{matt@@mattcraddock.com}
 #'@import ggplot2
 #'@import shiny
-#'@import miniUI
 #'@param data `eeg_data`, `eeg_epochs`, or `eeg_ICA` object to be plotted.
 #'@param ... Other parameters passed to browsing functions.
 #'@export
@@ -44,7 +43,7 @@ browse_data.eeg_ICA <- function(data,
                             inline = TRUE),
         ),
     bslib::layout_column_wrap(
-      plotOutput("topo_ica", height = "300px"),
+      plotOutput("topo_ica", height = "400px"),
       plotOutput("comp_img"),
       plotOutput("comp_psd"),
       plotOutput("comp_tc"),
@@ -158,69 +157,63 @@ browse_data.eeg_data <- function(data,
                            q = 4)
   }
 
-  ui <- miniPage(
-      gadgetTitleBar("Continuous data browser"),
-      miniTabstripPanel(
-        miniTabPanel(title = "Butterfly",
-                     icon = icon("chart-line"),
-                     miniContentPanel(
-                       fillCol(
-                         flex = c(4, NA, 1),
-                         plotOutput("butterfly",
-                                    height = "100%"),
-                         sliderInput("time_range",
-                                     label = "Display start time",
-                                     step = 1,
-                                     min = 0,
-                                     max = max(unique(data$timings$time)),
-                                     value = min(unique(data$timings$time)),
-                                     width = "100%"),
-                         fillRow(
-                           numericInput("sig_time",
-                                        "Display length",
-                                        value = sig_length,
-                                        min = 1,
-                                        max = 60),
-                           #numericInput("uV_scale", "Scale (microvolts)", value
+  ui <- bslib::page_fillable(
+      title = ("Continuous data browser"),
+      bslib::navset_tab(
+        bslib::nav_panel(
+          title = "Butterfly",
+          icon = icon("chart-line"),
+          bslib::card(
+            plotOutput("butterfly"),
+            sliderInput("time_range",
+                        label = "Display start time",
+                        step = 1,
+                        min = 0,
+                        max = max(unique(data$timings$time)),
+                        value = min(unique(data$timings$time)),
+                        width = "100%"),
+            bslib::layout_columns(
+              numericInput("sig_time",
+                           "Display length",
+                           value = sig_length,
+                           min = 1,
+                           max = 60),
+              #numericInput("uV_scale", "Scale (microvolts)", value
                            #= 50, min = 1),
-                           checkboxInput("dc_offset",
-                                         "Remove DC offset",
-                                         value = TRUE)
-                         )
-                       )
-                     )
+              checkboxInput("dc_offset",
+                            "Remove DC offset",
+                            value = TRUE)
+              )
+            )
         ),
-        miniTabPanel(title = "Individual",
-                     miniContentPanel(
-                       wellPanel(
-                         plotOutput("time_plot"),
-                         style = "overflow-y:scroll; max-height: 800px"
-                       ),
-                       fillPage(
-                         fillCol(
-                           flex = c(NA, 2),
-                           sliderInput("time_range_ind",
-                                       label = "Display start time",
-                                       step = 1,
-                                       min = 0,
-                                       max = max(unique(data$timings$time)),
-                                       value = min(unique(data$timings$time)),
-                                       width = "100%"),
-                           fillRow(
-                             numericInput("sig_time_ind",
-                                          "Display length",
-                                          sig_length,
-                                          min = 1, max = 60),
-                             checkboxInput("dc_offset_ind",
-                                           "Remove DC offset",
-                                           value = TRUE)
+        bslib::nav_panel(
+          title = "Individual",
+          icon = icon("chart-line"),
+          bslib::card(
+            wellPanel(
+              plotOutput("time_plot"),
+              style = "overflow-y:scroll; max-height: 800px"
+              ),
+            sliderInput("time_range_ind",
+                        label = "Display start time",
+                        step = 1,
+                        min = 0,
+                        max = max(unique(data$timings$time)),
+                        value = min(unique(data$timings$time)),
+                        width = "100%"),
+            bslib::layout_columns(
+              numericInput("sig_time_ind",
+                           "Display length",
+                           sig_length,
+                           min = 1, max = 60),
+              checkboxInput("dc_offset_ind",
+                            "Remove DC offset",
+                            value = TRUE)
                            )
                          )
                        )
                      )
         )
-      )
-    )
 
     server <- function(input,
                        output,

--- a/R/data_viewers.R
+++ b/R/data_viewers.R
@@ -26,35 +26,30 @@ browse_data <- function(data, ...) {
 browse_data.eeg_ICA <- function(data,
                                 ...) {
 
-  ui <- miniUI::miniPage(
-    gadgetTitleBar("ICA dashboard"),
-    miniUI::miniContentPanel(
-      fillPage(
-        fillRow(
-          fillCol(
-            shiny::selectInput("icomp",
-                               label = NULL,
-                               names(data$signals))
-          ),
-          fillCol(
-            shiny::radioButtons("reject_comps",
-                                label = NULL,
-                                choices = c("Keep", "Reject"),
-                                inline = TRUE)
-          ),
-        height = "15%"),
-        fillRow(
-          fillCol(
-            plotOutput("topo_ica", height = "100%"),
-            plotOutput("comp_psd", height = "100%"),
-            ),
-          fillCol(
-            plotOutput("comp_img", height = "100%"),
-            plotOutput("comp_tc", height = "100%")
-            ),
-          height = "85%"
-          )
-        )
+  ui <- bslib::page_fillable(
+    bslib::card(
+      tags$span(
+          "ICA Dashboard",
+          shiny::actionButton("done", "Done", class = "btn-success", style ="align-right")
+        ),
+        min_height = "85px"  #))
+    ),
+    bslib::layout_columns(
+        shiny::selectInput("icomp",
+                           label = NULL,
+                           names(data$signals)),
+        shiny::radioButtons("reject_comps",
+                            label = NULL,
+                            choices = c("Keep", "Reject"),
+                            inline = TRUE),
+        ),
+    bslib::layout_column_wrap(
+      plotOutput("topo_ica", height = "300px"),
+      plotOutput("comp_img"),
+      plotOutput("comp_psd"),
+      plotOutput("comp_tc"),
+      width = 1/2,
+      heights_equal = "all"
       )
   )
 

--- a/R/data_viewers.R
+++ b/R/data_viewers.R
@@ -27,11 +27,11 @@ browse_data.eeg_ICA <- function(data,
 
   ui <- bslib::page_fillable(
     bslib::card(
-      tags$span(
-          "ICA Dashboard",
-          shiny::actionButton("done", "Done", class = "btn-success", style ="align-right")
+      shiny::tags$span(
+        "ICA Dashboard",
+        shiny::actionButton("done", "Done", class = "btn-success", style ="align-right")
         ),
-        min_height = "85px"  #))
+      min_height = "85px"
     ),
     bslib::layout_columns(
         shiny::selectInput("icomp",
@@ -43,10 +43,10 @@ browse_data.eeg_ICA <- function(data,
                             inline = TRUE),
         ),
     bslib::layout_column_wrap(
-      plotOutput("topo_ica", height = "400px"),
-      plotOutput("comp_img"),
-      plotOutput("comp_psd"),
-      plotOutput("comp_tc"),
+      shiny::plotOutput("topo_ica", height = "400px"),
+      shiny::plotOutput("comp_img"),
+      shiny::plotOutput("comp_psd"),
+      shiny::plotOutput("comp_tc"),
       width = 1/2,
       heights_equal = "all"
       )
@@ -116,7 +116,7 @@ browse_data.eeg_ICA <- function(data,
       comp_status
       })
     shiny::observeEvent(input$done, {
-      returnValue <- reactiveValuesToList(comp_status)
+      returnValue <- shiny::reactiveValuesToList(comp_status)
       returnValue <-
         names(returnValue)[vapply(returnValue,
                                   function(x) identical(x, "Reject"),
@@ -124,11 +124,11 @@ browse_data.eeg_ICA <- function(data,
       shiny::stopApp(returnValue)
     })
 
-    session$onSessionEnded(stopApp)
+    session$onSessionEnded(shiny::stopApp)
   }
-  runGadget(ui,
+  shiny::runGadget(ui,
             server,
-            viewer = paneViewer(minHeight = 600))
+            viewer = shiny::paneViewer(minHeight = 600))
 }
 
 #' @export
@@ -162,10 +162,10 @@ browse_data.eeg_data <- function(data,
       bslib::navset_tab(
         bslib::nav_panel(
           title = "Butterfly",
-          icon = icon("chart-line"),
+          icon = shiny::icon("chart-line"),
           bslib::card(
-            plotOutput("butterfly"),
-            sliderInput("time_range",
+            shiny::plotOutput("butterfly"),
+            shiny::sliderInput("time_range",
                         label = "Display start time",
                         step = 1,
                         min = 0,
@@ -173,14 +173,14 @@ browse_data.eeg_data <- function(data,
                         value = min(unique(data$timings$time)),
                         width = "100%"),
             bslib::layout_columns(
-              numericInput("sig_time",
+              shiny::numericInput("sig_time",
                            "Display length",
                            value = sig_length,
                            min = 1,
                            max = 60),
               #numericInput("uV_scale", "Scale (microvolts)", value
                            #= 50, min = 1),
-              checkboxInput("dc_offset",
+              shiny::checkboxInput("dc_offset",
                             "Remove DC offset",
                             value = TRUE)
               )
@@ -188,13 +188,13 @@ browse_data.eeg_data <- function(data,
         ),
         bslib::nav_panel(
           title = "Individual",
-          icon = icon("chart-line"),
+          icon = shiny::icon("chart-line"),
           bslib::card(
-            wellPanel(
-              plotOutput("time_plot"),
+            shiny::wellPanel(
+              shiny::plotOutput("time_plot"),
               style = "overflow-y:scroll; max-height: 800px"
               ),
-            sliderInput("time_range_ind",
+            shiny::sliderInput("time_range_ind",
                         label = "Display start time",
                         step = 1,
                         min = 0,
@@ -202,11 +202,11 @@ browse_data.eeg_data <- function(data,
                         value = min(unique(data$timings$time)),
                         width = "100%"),
             bslib::layout_columns(
-              numericInput("sig_time_ind",
+              shiny::numericInput("sig_time_ind",
                            "Display length",
                            sig_length,
                            min = 1, max = 60),
-              checkboxInput("dc_offset_ind",
+              shiny::checkboxInput("dc_offset_ind",
                             "Remove DC offset",
                             value = TRUE)
                            )
@@ -219,7 +219,7 @@ browse_data.eeg_data <- function(data,
                        output,
                        session) {
 
-      output$butterfly <- renderPlot({
+      output$butterfly <- shiny::renderPlot({
         # select only the time range that we want to display
         tmp_data <- select_times(data,
                                  time_lim = c(input$time_range,
@@ -236,7 +236,7 @@ browse_data.eeg_data <- function(data,
         zz
       })
 
-      output$time_plot <- renderPlot({
+      output$time_plot <- shiny::renderPlot({
         tmp_data <- select_times(data,
                                  time_lim = c(input$time_range_ind,
                                               input$time_range_ind + input$sig_time_ind))
@@ -272,14 +272,14 @@ browse_data.eeg_data <- function(data,
         init_plot
       }, height = 2000)
 
-      observeEvent(input$done, {
+      shiny::observeEvent(input$done, {
         stopApp()
       })
       session$onSessionEnded(stopApp)
     }
-  runGadget(ui,
+  shiny::runGadget(ui,
             server,
-            viewer = paneViewer(minHeight = 600))
+            viewer = shiny::paneViewer(minHeight = 600))
 }
 
 #'@export
@@ -454,7 +454,7 @@ browse_data.eeg_epochs <- function(data,
     shiny::observeEvent(input$done, {
       shiny::stopApp()
     })
-    session$onSessionEnded(stopApp)
+    session$onSessionEnded(shiny::stopApp)
   }
   shiny::runGadget(ui,
                    server,

--- a/R/data_viewers.R
+++ b/R/data_viewers.R
@@ -175,7 +175,7 @@ browse_data.eeg_data <- function(data,
             shiny::plotOutput("time_plot"),
             style = "overflow-y:scroll; max-height: 800px"
           ),
-        ),
+        )
       ),
       footer =
         bslib::card(
@@ -294,9 +294,6 @@ browse_data.eeg_epochs <- function(data,
           class = "resize-vertical"
         ),
       ),
-
-      #   #numericInput("uV_scale", "Scale (microvolts)",
-      # #max(data$amplitude), min = 10, value = 100),
       bslib::nav_panel(
         title = bslib::tooltip(
           shiny::tags$span(
@@ -309,7 +306,7 @@ browse_data.eeg_epochs <- function(data,
           shiny::plotOutput("time_plot"),
           style = "overflow-y:scroll; max-height: 800px",
           class = "resize-vertical"
-        ),
+        )
       ),
       footer = bslib::card(
         shiny::sliderInput("time_range",
@@ -322,7 +319,10 @@ browse_data.eeg_epochs <- function(data,
                            width = "100%"),
         shiny::checkboxInput("dc_offset",
                              "Remove DC offset",
-                             value = FALSE)
+                             value = FALSE),
+        shiny::numericInput("uV_scale",
+                            "Scale (microvolts)",
+                            value = 50, step = 1),
       )
     )
   )
@@ -363,7 +363,10 @@ browse_data.eeg_epochs <- function(data,
         ) +
         geom_vline(xintercept = max(unique(tmp_data$time))) +
         geom_vline(xintercept = 0,
-                   linetype = "longdash")
+                   linetype = "longdash",
+                   alpha = 0.2) +
+        coord_cartesian(ylim = c(-input$uV_scale, input$uV_scale),
+                        expand = FALSE)
       butter_out
     })
 
@@ -385,8 +388,10 @@ browse_data.eeg_epochs <- function(data,
                                          y = amplitude)) +
           geom_line() +
           facet_grid(electrode ~ epoch,
-                     scales = "free_y",
+                     #scales = "free_y",
                      switch = "y") +
+          coord_cartesian(ylim = c(-input$uV_scale, input$uV_scale),
+                          expand = FALSE) +
           theme_minimal() +
           theme(
             axis.text.y = element_blank(),
@@ -400,12 +405,15 @@ browse_data.eeg_epochs <- function(data,
           scale_x_continuous(expand = c(0, 0)) +
           geom_vline(xintercept = max(unique(tmp_data$time))) +
           geom_vline(xintercept = 0,
-                     linetype = "longdash") +
+                     linetype = "longdash",
+                     alpha = 0.2) +
           labs(x = "Time (s)")
         init_plot
       },
       height = 2500),
-      input$dc_offset, tmp_data()
+      input$dc_offset,
+      tmp_data(),
+      input$uV_scale
     )
 
     shiny::observeEvent(input$done, {
@@ -417,3 +425,4 @@ browse_data.eeg_epochs <- function(data,
                    server,
                    viewer = shiny::paneViewer(minHeight = 600))
 }
+

--- a/R/data_viewers.R
+++ b/R/data_viewers.R
@@ -190,7 +190,10 @@ browse_data.eeg_data <- function(data,
             width = "100%"),
           shiny::checkboxInput("dc_offset",
                                "Remove DC offset",
-                               value = TRUE)
+                               value = TRUE),
+          shiny::numericInput("uV_scale",
+                              "Scale (microvolts)",
+                              value = 50, step = 1),
           )
       )
     )
@@ -214,7 +217,9 @@ browse_data.eeg_data <- function(data,
       butterfly_plot <- plot_butterfly(tmp_data,
                                        legend = FALSE,
                                        continuous = TRUE)
-      butterfly_plot
+      butterfly_plot +
+        coord_cartesian(ylim = c(-input$uV_scale, input$uV_scale),
+                        expand = FALSE)
     })
 
     output$time_plot <- shiny::renderPlot({
@@ -248,7 +253,9 @@ browse_data.eeg_data <- function(data,
           panel.grid.minor = element_blank(),
           panel.grid.major.y = element_blank()
         ) +
-        scale_x_continuous(expand = c(0, 0))
+        scale_x_continuous(expand = c(0, 0)) +
+        coord_cartesian(ylim = c(-input$uV_scale, input$uV_scale),
+                        expand = FALSE)
 
       init_plot
     }, height = 2000)

--- a/R/erp_scalp.R
+++ b/R/erp_scalp.R
@@ -320,30 +320,34 @@ interactive_scalp.eeg_epochs <- function(data,
   }
 
   ui <-
-      bslib::page_fillable(
+    bslib::page_fillable(
       bslib::navset_card_underline(
         bslib::nav_panel(
           title = "Whole scalp",
-          icon = icon(name = "circle", lib = "font-awesome"),
+          icon = icon(name = "circle",
+                      lib = "font-awesome"),
           plotOutput("Scalp",
                      click = "click_plot"),
           verbatimTextOutput("click_info")
         ),
         bslib::nav_panel(
           title = "Selected electrodes",
-          icon = icon("chart-line"),
+          icon = icon("chart-line",
+                      lib = "font-awesome"),
           plotOutput("Selected"),
-          bslib::tooltip(
-            actionButton("avg", "Mean"),
-            "Plot the mean of the selected electrodes",
-            placement = "right"
-          ),
-          actionButton("single", "Plot individual electrodes")
+          bslib::layout_column_wrap(
+            bslib::tooltip(
+              actionButton("avg", "Mean"),
+              "Plot the mean of the selected electrodes"
+              ),
+            bslib::tooltip(
+              actionButton("single", "Plot individual electrodes"),
+              "Butterfly plot with each selected electrode shown separately"
+              )
           )
         )
       )
-
-
+    )
 
   server <- function(input,
                      output,

--- a/R/plot_butterfly.R
+++ b/R/plot_butterfly.R
@@ -298,7 +298,7 @@ create_bf <- function(data,
       butterfly_plot +
       geom_line(colour = "black",
                 aes(group = electrode),
-                alpha = 0.2) +
+                alpha = 0.4) +
       labs(x = "Time (s)",
            y = ylab,
            colour = "") +

--- a/R/view_ica.R
+++ b/R/view_ica.R
@@ -49,73 +49,73 @@ view_ica <- function(data) {
              verbose = FALSE)
 
   ui <-
-    navbarPage(
+    shiny::navbarPage(
       title = "EEG decomposition viewer",
       id = "main_page",
       inverse = TRUE,
       collapsible = TRUE,
-      tabPanel(
-        "Topographies", plotOutput("comp_topos", dblclick = "topo_click")
+      shiny::tabPanel(
+        "Topographies", shiny::plotOutput("comp_topos", dblclick = "topo_click")
       ),
-      tabPanel(
+      shiny::tabPanel(
         "Timecourses",
-        plotOutput("ica_butterflies",
+        shiny::plotOutput("ica_butterflies",
                    hover = "butter_click",
-                   brush = brushOpts(id = "butter_brush",
+                   brush = shiny::brushOpts(id = "butter_brush",
                                      resetOnNew = TRUE),
                    dblclick = "butter_dbl"),
-        tableOutput("info"),
-        tags$p(span("Hover over lines to see component details.")),
-        tags$p("To zoom, drag-click to highlight where you want to zoom, then double-click to zoom. Double-click again to zoom back out.")
+        shiny::tableOutput("info"),
+        shiny::tags$p(shiny::span("Hover over lines to see component details.")),
+        shiny::tags$p("To zoom, drag-click to highlight where you want to zoom, then double-click to zoom. Double-click again to zoom back out.")
       ),
-      tabPanel(
+      shiny::tabPanel(
         "PSDs",
-        plotOutput(
+        shiny::plotOutput(
           "ica_psd",
           hover = "psd_click",
-          brush = brushOpts(id = "psd_brush",
+          brush = shiny::brushOpts(id = "psd_brush",
                             resetOnNew = TRUE),
           dblclick = "psd_dbl"
         ),
-        tableOutput("psd_info"),
-        tags$p(span("Hover over lines to see component details.")),
-        tags$p("To zoom, drag-click to highlight where you want to zoom, then double-click to zoom. Double-click again to zoom back out.")
+        shiny::tableOutput("psd_info"),
+        shiny::tags$p(shiny::span("Hover over lines to see component details.")),
+        shiny::tags$p("To zoom, drag-click to highlight where you want to zoom, then double-click to zoom. Double-click again to zoom back out.")
       ),
-      tabPanel("Individual",
-        sidebarLayout(
-          sidebarPanel(
-                       selectInput(
-                         "comp_no", "Component:",
-                         channel_names(data)
-                       ),
-                       shiny::radioButtons("reject_comps",
-                                           label = NULL,
-                                           choices = c("Keep", "Reject"),
-                                           inline = TRUE),
-                       width = 3),
-          mainPanel(
-                    fluidRow(
-                      column(plotOutput("indiv_topo"), width = 6),
-                      column(plotOutput("indiv_erpim"), width = 6)
-                    ),
-                    fluidRow(
-                      column(plotOutput("indiv_psd"), width = 6),
-                      column(plotOutput("indiv_tc"), width = 6)
-                    ),
-                    width = 9)
-        )
-      ),
-      tabPanel("Output",
-               tableOutput("reject_table"),
-               checkboxGroupInput("output_choices",
-                 label = "Output to return",
-                 choices = list(
-                                "Components to reject" = "reject",
-                                "Components to keep" = "keep",
-                                "Reconstructed data" = "data")
-               ),
-               actionButton("done",
-                            "Press to close app and return to console"))
+      shiny::tabPanel("Individual",
+        shiny::sidebarLayout(
+          shiny::sidebarPanel(
+            shiny::selectInput(
+              "comp_no", "Component:",
+              channel_names(data)
+              ),
+            shiny::radioButtons("reject_comps",
+                                label = NULL,
+                                choices = c("Keep", "Reject"),
+                                inline = TRUE),
+            width = 3),
+          shiny::mainPanel(
+            shiny::fluidRow(
+              shiny::column(shiny::plotOutput("indiv_topo"), width = 6),
+              shiny::column(shiny::plotOutput("indiv_erpim"), width = 6)
+              ),
+            shiny::fluidRow(
+              shiny::column(shiny::plotOutput("indiv_psd"), width = 6),
+              shiny::column(shiny::plotOutput("indiv_tc"), width = 6)
+              ),
+            width = 9)
+          )
+        ),
+      shiny::tabPanel("Output",
+                      shiny::tableOutput("reject_table"),
+                      shiny::checkboxGroupInput("output_choices",
+                                                label = "Output to return",
+                                                choices = list(
+                                                  "Components to reject" = "reject",
+                                                  "Components to keep" = "keep",
+                                                  "Reconstructed data" = "data")
+                                                ),
+                      shiny::actionButton("done",
+                                          "Press to close app and return to console"))
 
     )
 
@@ -123,10 +123,10 @@ view_ica <- function(data) {
                      output,
                      session) {
 
-    comp_status <- reactiveValues()
-    ranges <- reactiveValues(x = NULL,
+    comp_status <- shiny::reactiveValues()
+    ranges <- shiny::reactiveValues(x = NULL,
                              y = NULL)
-    b_ranges <- reactiveValues(x = NULL,
+    b_ranges <- shiny::reactiveValues(x = NULL,
                                y = NULL)
 
     output$comp_topos <-
@@ -145,7 +145,7 @@ view_ica <- function(data) {
       )
 
     output$ica_psd <-
-      renderPlot({
+      shiny::renderPlot({
         ggplot(psd_ica,
                aes(x = frequency,
                    y = power,
@@ -157,7 +157,7 @@ view_ica <- function(data) {
                           expand = FALSE)
       })
 
-    output$info <- renderTable({
+    output$info <- shiny::renderTable({
       as.data.frame(
         shiny::nearPoints(ica_erps,
                           input$butter_click,
@@ -168,7 +168,7 @@ view_ica <- function(data) {
       )
     })
 
-    output$psd_info <- renderTable({
+    output$psd_info <- shiny::renderTable({
       as.data.frame(
         shiny::nearPoints(psd_ica,
                           input$psd_click,
@@ -178,7 +178,7 @@ view_ica <- function(data) {
     })
 
     output$indiv_topo <- shiny::bindCache(
-      renderPlot({
+      shiny::renderPlot({
       topoplot(data,
                input$comp_no,
                verbose = FALSE)
@@ -230,7 +230,7 @@ view_ica <- function(data) {
     }, res = 96),
     input$icomp)
 
-    observeEvent(input$psd_dbl, {
+    shiny::observeEvent(input$psd_dbl, {
       brush <- input$psd_brush
       if (!is.null(brush)) {
         ranges$x <- c(brush$xmin, brush$xmax)
@@ -241,7 +241,7 @@ view_ica <- function(data) {
       }
     })
 
-    observeEvent(input$butter_dbl, {
+    shiny::observeEvent(input$butter_dbl, {
       brush <- input$butter_brush
       if (!is.null(brush)) {
         b_ranges$x <- c(brush$xmin,
@@ -254,34 +254,34 @@ view_ica <- function(data) {
       }
     })
 
-    observeEvent(input$topo_click, {
+    shiny::observeEvent(input$topo_click, {
       selected_topo <- as.data.frame(
         shiny::nearPoints(ica_topoplots$data,
                           input$topo_click,
                           threshold = 20,
                           maxpoints = 1)
       )
-      updateNavbarPage(inputId = "main_page",
+      shiny::updateNavbarPage(inputId = "main_page",
                        selected = "Individual")
-      updateSelectInput(inputId = "comp_no",
+      shiny::updateSelectInput(inputId = "comp_no",
                         selected = selected_topo$component)
     })
 
 
-    observeEvent(input$comp_no, {
-      updateRadioButtons(inputId = "reject_comps",
+    shiny::observeEvent(input$comp_no, {
+      shiny::updateRadioButtons(inputId = "reject_comps",
                          choices = c("Keep", "Reject"),
                          selected = comp_status[[input$comp_no]],
                          inline = TRUE)
     })
 
-    observeEvent(input$reject_comps, {
-      comp_status[[isolate(input$comp_no)]] <- input$reject_comps
+    shiny::observeEvent(input$reject_comps, {
+      comp_status[[shiny::isolate(input$comp_no)]] <- input$reject_comps
       comp_status
     })
 
-    output$reject_table <- renderTable({
-      rejects <- reactiveValuesToList(comp_status)
+    output$reject_table <- shiny::renderTable({
+      rejects <- shiny::reactiveValuesToList(comp_status)
       rejects <-
         names(rejects)[vapply(rejects,
                               function(x) identical(x, "Reject"),
@@ -290,8 +290,8 @@ view_ica <- function(data) {
     }
     )
 
-    observeEvent(input$done, {
-      outputs <- isolate(input$output_choices)
+    shiny::observeEvent(input$done, {
+      outputs <- shiny::isolate(input$output_choices)
 
       if (is.null(outputs)) {
         message("No output requested.")
@@ -302,7 +302,7 @@ view_ica <- function(data) {
           length(outputs)
         )
         names(returnValue) <- outputs
-        rejects <- reactiveValuesToList(isolate(comp_status))
+        rejects <- shiny::reactiveValuesToList(shiny::isolate(comp_status))
         rejects <-
           names(rejects)[vapply(rejects,
                                 function(x) identical(x, "Reject"),


### PR DESCRIPTION
Recodes the various interactive data viewers from using miniUI, which hasn't been updated in years, to `bslib`.

Closes #138 